### PR TITLE
fix(imports): add table model to import on module

### DIFF
--- a/userdatamodel/models.py
+++ b/userdatamodel/models.py
@@ -4,4 +4,4 @@ from user import (
     CloudProvider, StorageAccess, Bucket,
     ComputeAccess, UserToBucket,
     AuthorizationProvider, S3Credential,
-    HMACKeyPair, HMACKeyPairArchive)
+    HMACKeyPair, HMACKeyPairArchive, ProjectToBucket)


### PR DESCRIPTION
added ProjectToBucket to models to use it to check the existence of buckets assigned to a project before removing it.