### PR TITLE
fix(setup.py): bump sqlalchemy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='userdatamodel',
     packages=find_packages(),
     install_requires=[
-        'sqlalchemy==0.9.9',
+        'sqlalchemy==1.1.9',
     ],
     scripts=[
         'bin/userdatamodel-init',


### PR DESCRIPTION
/user-api depends on this as well as /flask-postgres-session which require different sqlalchemy versions - this patch fixes that (both now require sqlalchemy 1.1.9 - latest is 1.1.14)

after we merge this pull request will we get a new 'release' to point user-api at?

(PlanX) reuben@reuben-pasquini-cdis:~/Code/PlanX$ grep userdatamodel user-api/setup.py 
        "userdatamodel",
        "git+https://github.com/uc-cdis/userdatamodel.git@1.0.2#egg=userdatamodel",
