### PR TITLE
feat(group): refactor user to group

### DIFF
--- a/userdatamodel/models.py
+++ b/userdatamodel/models.py
@@ -1,5 +1,5 @@
 from user import (
-    User, Project, ResearchGroup, AccessPrivilege,
+    User, Project, Group, UserToGroup, AccessPrivilege,
     IdentityProvider, Application, Certificate,
     CloudProvider, StorageAccess, Bucket,
     ComputeAccess, UserToBucket,


### PR DESCRIPTION
```

In [1]: from userdatamodel.driver import SQLAlchemyDriver

In [2]: from userdatamodel.models import *

In [3]: DB = 'postgresql://test:test@localhost:5432/userapi'

In [4]: db = SQLAlchemyDriver(DB); s = db.Session()

In [5]: group = s.query(Group).first()

In [6]: group
Out[6]: <userdatamodel.user.Group at 0x112427850>

In [7]: group.id
Out[7]: 1

In [8]: u = s.query(User).first()

In [9]: ug = UserToGroup(user_id=u.id, group_id=group.id)

In [10]: s.add(ug)

In [11]: s.commit()

In [12]: group.users
Out[12]: [{"username": "testb", "idp_id": 44, "is_admin": false, "active": null, "id": 770, "projects": "{}", "project_access": "{}", "group_accesses": "{}", "id_from_idp": null, "group_privileges": "{}", "department_id": null}]

In [13]: u.groups
Out[13]: [<userdatamodel.user.Group object at 0x112427850>]
```
This just create new group table and user->group relation table. It will just ignore(deprecate) old tables so no migration script is needed