### PR TITLE
feat(db_setup): ignore setup failure

### DIFF
--- a/bin/userdatamodel-init
+++ b/bin/userdatamodel-init
@@ -7,7 +7,9 @@ from userdatamodel.driver import SQLAlchemyDriver
 
 def main(**kwargs):
     db = SQLAlchemyDriver(
-        "postgresql://{username}:{password}@{host}/{db}".format(**kwargs))
+        "postgresql://{username}:{password}@{host}/{db}".format(**kwargs),
+        ignore_db_error=False,
+        )
     print 'initializing database'
     init_defaults(db)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'sqlalchemy==0.9.9',
+        'cdislogging',
     ],
     scripts=[
         'bin/userdatamodel-init',


### PR DESCRIPTION
change the default behavior of driver initiation to don't crash if it fails to migrate database
the migration is run automatically on init, which  means if we have mutliple api servers starting at the same time only one won't crach(race condition) with current setup