### PR TITLE
[PXP-2270] Feat/ddl delete

### DIFF
--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -96,9 +96,9 @@ class User(Base):
 
     group_privileges = relationship(
         "AccessPrivilege",
-        primaryjoin="user_to_group.c.user_id==User.id",
-        secondary="join(AccessPrivilege, Group, AccessPrivilege.group_id==Group.id)."
-        "join(user_to_group, Group.id == user_to_group.c.group_id)",
+        #primaryjoin="user_to_group.c.user_id==User.id",
+        #secondary="join(AccessPrivilege, Group, AccessPrivilege.group_id==Group.id)."
+        #"join(user_to_group, Group.id == user_to_group.c.group_id)",
         collection_class=PrivilegeDict,
     )
     group_accesses = association_proxy(

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -96,9 +96,10 @@ class User(Base):
 
     group_privileges = relationship(
         "AccessPrivilege",
-        #primaryjoin="user_to_group.c.user_id==User.id",
-        #secondary="join(AccessPrivilege, Group, AccessPrivilege.group_id==Group.id)."
-        #"join(user_to_group, Group.id == user_to_group.c.group_id)",
+        secondary="join(AccessPrivilege, Group, AccessPrivilege.group_id==Group.id)."
+        "join(user_to_group, Group.id == user_to_group.c.group_id)",
+        primaryjoin="user_to_group.c.user_id==User.id",
+        secondaryjoin="user_to_group.c.group_id==AccessPrivilege.group_id",
         collection_class=PrivilegeDict,
     )
     group_accesses = association_proxy(

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -94,21 +94,6 @@ class User(Base):
 
     groups = association_proxy("user_to_groups", "group")
 
-    group_privileges = relationship(
-        "AccessPrivilege",
-        #secondary="join(AccessPrivilege, Group, AccessPrivilege.group_id==Group.id)."
-        #"join(user_to_group, Group.id == user_to_group.c.group_id)",
-        secondary="user_to_group",
-        primaryjoin="user_to_group.c.user_id==User.id",
-        secondaryjoin="user_to_group.c.group_id==AccessPrivilege.group_id",
-        collection_class=PrivilegeDict,
-    )
-    group_accesses = association_proxy(
-        "group_privileges",
-        "privilege",
-        creator=lambda k, v: AccessPrivilege(privilege=v, pj=k),
-    )
-
     active = Column(Boolean)
     is_admin = Column(Boolean, default=False)
 
@@ -133,8 +118,6 @@ class User(Base):
             "department_id": self.department_id,
             "active": self.active,
             "is_admin": self.is_admin,
-            "group_privileges": str(self.group_privileges),
-            "group_accesses": str(self.group_accesses),
             "projects": str(self.projects),
             "project_access": str(self.project_access),
         }

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -96,10 +96,11 @@ class User(Base):
 
     group_privileges = relationship(
         "AccessPrivilege",
-        secondary="join(AccessPrivilege, Group, AccessPrivilege.group_id==Group.id)."
-        "join(user_to_group, Group.id == user_to_group.c.group_id)",
+        #secondary="join(AccessPrivilege, Group, AccessPrivilege.group_id==Group.id)."
+        #"join(user_to_group, Group.id == user_to_group.c.group_id)",
+        secondary="user_to_group",
         primaryjoin="user_to_group.c.user_id==User.id",
-        secondaryjoin="user_to_group.c.group_id==foreign(AccessPrivilege.group_id)",
+        secondaryjoin="user_to_group.c.group_id==AccessPrivilege.group_id",
         collection_class=PrivilegeDict,
     )
     group_accesses = association_proxy(

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -163,8 +163,7 @@ class HMACKeyPair(Base):
     user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
     user = relationship(
             'User',
-            backref=backref('hmac_keypairs', cascade="all, delete-orphan"),
-            passive_deletes=True
+            backref=backref('hmac_keypairs', cascade="all, delete-orphan", passive_deletes=True),
     )
 
     access_key = Column(String)
@@ -224,8 +223,7 @@ class HMACKeyPairArchive(Base):
     user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
     user = relationship(
             'User',
-            backref=backref('archive_keypairs', cascade="all, delete-orphan"),
-            passive_deletes=True
+            backref=backref('archive_keypairs', cascade="all, delete-orphan", passive_deletes=True),
     )
 
     access_key = Column(String)
@@ -244,15 +242,13 @@ class UserToGroup(Base):
     user_id = Column('user_id', Integer, ForeignKey('User.id', ondelete='CASCADE'), primary_key=True)
     user = relationship(
         User,
-        backref=backref('user_to_groups', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('user_to_groups', cascade='all, delete-orphan', passive_deletes=True),
     )
 
     group_id = Column('group_id', Integer, ForeignKey('Group.id', ondelete='CASCADE'), primary_key=True)
     group = relationship(
         'Group',
-        backref=backref('user_to_groups', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('user_to_groups', cascade='all, delete-orphan', passive_deletes=True),
     )
 
     roles = Column("roles", ARRAY(String))
@@ -301,22 +297,20 @@ class AccessPrivilege(Base):
             'accesses_privilege',
             collection_class=attribute_mapped_collection('pj'),
             cascade="all, delete-orphan",
+            passive_deletes=True,
         ),
-        passive_deletes=True
     )
 
     group_id = Column(Integer, ForeignKey('Group.id', ondelete='CASCADE'))
     group = relationship(
         'Group',
-        backref=backref('accesses_privilege', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('accesses_privilege', cascade='all, delete-orphan', passive_deletes=True),
     )
 
     project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
     project = relationship(
         'Project',
-        backref=backref('accesses_privilege', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('accesses_privilege', cascade='all, delete-orphan', passive_deletes=True),
     )
     pj = association_proxy("project", "auth_id")
 
@@ -324,8 +318,7 @@ class AccessPrivilege(Base):
     provider_id = Column(Integer, ForeignKey('authorization_provider.id', ondelete='CASCADE'))
     auth_provider = relationship(
         'AuthorizationProvider',
-        backref=backref('acls', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('acls', cascade='all, delete-orphan', passive_deletes=True),
     )
 
     def __str__(self):
@@ -351,15 +344,13 @@ class UserToBucket(Base):
     user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
     user = relationship(
         User,
-        backref=backref('user_to_buckets', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('user_to_buckets', cascade='all, delete-orphan', passive_deletes=True),
     )
 
     bucket_id = Column(Integer, ForeignKey('bucket.id', ondelete='CASCADE'))
     bucket = relationship(
         'Bucket',
-        backref=backref('user_to_buckets', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('user_to_buckets', cascade='all, delete-orphan', passive_deletes=True),
     )
     privilege = Column(ARRAY(String))
 
@@ -404,8 +395,7 @@ class Bucket(Base):
     provider_id = Column(Integer, ForeignKey('cloud_provider.id', ondelete='CASCADE'))
     provider = relationship(
        'CloudProvider',
-       backref=backref('buckets', cascade='all, delete-orphan'),
-       passive_deletes=True
+       backref=backref('buckets', cascade='all, delete-orphan', passive_deletes=True),
     )
     users = association_proxy(
         'user_to_buckets',
@@ -457,15 +447,13 @@ class ProjectToBucket(Base):
     project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
     project = relationship(
         Project,
-        backref=backref('project_to_buckets', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('project_to_buckets', cascade='all, delete-orphan', passive_deletes=True),
     )
 
     bucket_id = Column(Integer, ForeignKey('bucket.id', ondelete='CASCADE'))
     bucket = relationship(
         'Bucket',
-        backref=backref('project_to_buckets', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('project_to_buckets', cascade='all, delete-orphan', passive_deletes=True),
     )
     privilege = Column(ARRAY(String))
 
@@ -477,16 +465,16 @@ class ComputeAccess(Base):
 
     # compute access can be linked to a project/research group/user
     project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
-    project = relationship('Project', backref=backref('compute_access', cascade='all, delete-orphan'), passive_deletes=True)
+    project = relationship('Project', backref=backref('compute_access', cascade='all, delete-orphan', passive_deletes=True))
 
     user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
-    user = relationship('User', backref=backref('compute_access', cascade='all, delete-orphan'), passive_deletes=True)
+    user = relationship('User', backref=backref('compute_access', cascade='all, delete-orphan', passive_deletes=True))
 
     group_id = Column(Integer, ForeignKey('Group.id', ondelete='CASCADE'))
-    group = relationship('Group', backref=backref('compute_access', cascade='all, delete-orphan'), passive_deletes=True)
+    group = relationship('Group', backref=backref('compute_access', cascade='all, delete-orphan', passive_deletes=True))
 
     provider_id = Column(Integer, ForeignKey('cloud_provider.id', ondelete='CASCADE'))
-    provider = relationship('CloudProvider', backref=backref('compute_access', cascade='all, delete-orphan'), passive_deletes=True)
+    provider = relationship('CloudProvider', backref=backref('compute_access', cascade='all, delete-orphan', passive_deletes=True))
 
     instances = Column(Integer)
     cores = Column(Integer)
@@ -512,16 +500,16 @@ class StorageAccess(Base):
     id = Column(Integer, primary_key=True)
 
     project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
-    project = relationship('Project', backref=backref('storage_access', cascade='all, delete-orphan'), passive_deletes=True)
+    project = relationship('Project', backref=backref('storage_access', cascade='all, delete-orphan', passive_deletes=True))
 
     user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
-    user = relationship('User', backref=backref('storage_access', cascade='all, delete-orphan'), passive_deletes=True)
+    user = relationship('User', backref=backref('storage_access', cascade='all, delete-orphan', passive_deletes=True))
 
     group_id = Column(Integer, ForeignKey('Group.id', ondelete='CASCADE'))
-    group = relationship('Group', backref=backref('storage_access', cascade='all, delete-orphan'), passive_deletes=True)
+    group = relationship('Group', backref=backref('storage_access', cascade='all, delete-orphan', passive_deletes=True))
 
     provider_id = Column(Integer, ForeignKey('cloud_provider.id', ondelete='CASCADE'))
-    provider = relationship('CloudProvider', backref=backref('storage_access', cascade='all, delete-orphan'), passive_deletes=True)
+    provider = relationship('CloudProvider', backref=backref('storage_access', cascade='all, delete-orphan', passive_deletes=True))
 
     max_objects = Column(BigInteger)
     max_size = Column(BigInteger)
@@ -580,8 +568,7 @@ class Certificate(Base):
     application_id = Column(Integer, ForeignKey('application.id', ondelete='CASCADE'))
     application = relationship(
             "Application",
-            backref=backref("certificates", cascade="all, delete-orphan"),
-            passive_deletes=True
+            backref=backref("certificates", cascade="all, delete-orphan", passive_deletes=True),
     )
     name = Column(String(40))
     extension = Column(String)
@@ -599,8 +586,7 @@ class S3Credential(Base):
     user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
     user = relationship(
             'User',
-            backref=backref('s3credentials', cascade='all, delete-orphan'),
-            passive_deletes=True
+            backref=backref('s3credentials', cascade='all, delete-orphan', passive_deletes=True),
     )
 
     access_key = Column(String)
@@ -617,6 +603,5 @@ class Tag(Base):
     value = Column(String)
     user = relationship(
         'User',
-        backref=backref('tags', cascade='all, delete-orphan'),
-        passive_deletes=True
+        backref=backref('tags', cascade='all, delete-orphan', passive_deletes=True),
     )

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -99,7 +99,7 @@ class User(Base):
         secondary="join(AccessPrivilege, Group, AccessPrivilege.group_id==Group.id)."
         "join(user_to_group, Group.id == user_to_group.c.group_id)",
         primaryjoin="user_to_group.c.user_id==User.id",
-        secondaryjoin="user_to_group.c.group_id==AccessPrivilege.group_id",
+        secondaryjoin="user_to_group.c.group_id==foreign(AccessPrivilege.group_id)",
         collection_class=PrivilegeDict,
     )
     group_accesses = association_proxy(

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -40,7 +40,7 @@ class PrivilegeDict(MappedCollection):
     @collection.internally_instrumented
     def __setitem__(self, key, value, _sa_initiator=None):
         # do something with key, value
-        if self.has_key(key):
+        if self.has_key(key) and value.privilege:
             for item in value.privilege:
                 if item not in self[key].privilege:
                     self[key].privilege.append(item)

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -161,8 +161,12 @@ class HMACKeyPair(Base):
     __tablename__ = "hmac_keypair"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id))
-    user = relationship("User", backref="hmac_keypairs")
+    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user = relationship(
+            'User',
+            backref=backref('hmac_keypairs', cascade="all, delete-orphan"),
+            passive_deletes=True
+    )
 
     access_key = Column(String)
     # AES-128 encrypted
@@ -218,8 +222,12 @@ class HMACKeyPairArchive(Base):
     __tablename__ = "hmac_keypair_archive"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id))
-    user = relationship("User", backref="archive_keypairs")
+    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user = relationship(
+            'User',
+            backref=backref('archive_keypairs', cascade="all, delete-orphan"),
+            passive_deletes=True
+    )
 
     access_key = Column(String)
     # AES-128 encrypted
@@ -233,16 +241,19 @@ class UserToGroup(Base):
     """
     Edge table between user and group
     """
-
-    __tablename__ = "user_to_group"
-    user_id = Column("user_id", Integer, ForeignKey("User.id"), primary_key=True)
+    __tablename__ = 'user_to_group'
+    user_id = Column('user_id', Integer, ForeignKey('User.id', ondelete='CASCADE'), primary_key=True)
     user = relationship(
-        User, backref=backref("user_to_groups", cascade="all, delete-orphan")
+        User,
+        backref=backref('user_to_groups', cascade='all, delete-orphan'),
+        passive_deletes=True
     )
 
-    group_id = Column("group_id", Integer, ForeignKey("Group.id"), primary_key=True)
+    group_id = Column('group_id', Integer, ForeignKey('Group.id', ondelete='CASCADE'), primary_key=True)
     group = relationship(
-        "Group", backref=backref("user_to_groups", cascade="all, delete-orphan")
+        'Group',
+        backref=backref('user_to_groups', cascade='all, delete-orphan'),
+        passive_deletes=True
     )
 
     roles = Column("roles", ARRAY(String))
@@ -284,30 +295,39 @@ class AccessPrivilege(Base):
     )
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id))
+    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
     user = relationship(
         User,
         backref=backref(
-            "accesses_privilege",
-            collection_class=attribute_mapped_collection("pj"),
+            'accesses_privilege',
+            collection_class=attribute_mapped_collection('pj'),
             cascade="all, delete-orphan",
         ),
+        passive_deletes=True
     )
 
-    group_id = Column(Integer, ForeignKey("Group.id"))
+    group_id = Column(Integer, ForeignKey('Group.id', ondelete='CASCADE'))
     group = relationship(
-        "Group", backref=backref("accesses_privilege", cascade="all, delete-orphan")
+        'Group',
+        backref=backref('accesses_privilege', cascade='all, delete-orphan'),
+        passive_deletes=True
     )
 
-    project_id = Column(Integer, ForeignKey("project.id"))
+    project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
     project = relationship(
-        "Project", backref=backref("accesses_privilege", cascade="all, delete-orphan")
+        'Project',
+        backref=backref('accesses_privilege', cascade='all, delete-orphan'),
+        passive_deletes=True
     )
     pj = association_proxy("project", "auth_id")
 
     privilege = Column(ARRAY(String))
-    provider_id = Column(Integer, ForeignKey("authorization_provider.id"))
-    auth_provider = relationship("AuthorizationProvider", backref="acls")
+    provider_id = Column(Integer, ForeignKey('authorization_provider.id', ondelete='CASCADE'))
+    auth_provider = relationship(
+        'AuthorizationProvider',
+        backref=backref('acls', cascade='all, delete-orphan'),
+        passive_deletes=True
+    )
 
     def __str__(self):
         str_out = {
@@ -325,18 +345,22 @@ class AccessPrivilege(Base):
 
 
 class UserToBucket(Base):
-    __tablename__ = "user_to_bucket"
+    """Unused"""
+    __tablename__ = 'user_to_bucket'
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id))
+    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
     user = relationship(
-        User, backref=backref("user_to_buckets", cascade="all, delete-orphan")
+        User,
+        backref=backref('user_to_buckets', cascade='all, delete-orphan'),
+        passive_deletes=True
     )
 
-    bucket_id = Column(Integer, ForeignKey("bucket.id"))
-
+    bucket_id = Column(Integer, ForeignKey('bucket.id', ondelete='CASCADE'))
     bucket = relationship(
-        "Bucket", backref=backref("user_to_buckets", cascade="all, delete-orphan")
+        'Bucket',
+        backref=backref('user_to_buckets', cascade='all, delete-orphan'),
+        passive_deletes=True
     )
     privilege = Column(ARRAY(String))
 
@@ -378,9 +402,15 @@ class Bucket(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String)
-    provider_id = Column(Integer, ForeignKey("cloud_provider.id"))
-    provider = relationship("CloudProvider", backref="buckets")
-    users = association_proxy("user_to_buckets", "user")
+    provider_id = Column(Integer, ForeignKey('cloud_provider.id', ondelete='CASCADE'))
+    provider = relationship(
+       'CloudProvider',
+       backref=backref('buckets', cascade='all, delete-orphan'),
+       passive_deletes=True
+    )
+    users = association_proxy(
+        'user_to_buckets',
+        'user')
 
 
 class CloudProvider(Base):
@@ -425,14 +455,19 @@ class ProjectToBucket(Base):
     __tablename__ = "project_to_bucket"
 
     id = Column(Integer, primary_key=True)
-    project_id = Column(Integer, ForeignKey("project.id"))
+    project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
     project = relationship(
-        Project, backref=backref("project_to_buckets", cascade="all, delete-orphan")
+        Project,
+        backref=backref('project_to_buckets', cascade='all, delete-orphan'),
+        passive_deletes=True
     )
 
-    bucket_id = Column(Integer, ForeignKey("bucket.id"))
-
-    bucket = relationship("Bucket", backref="project_to_buckets")
+    bucket_id = Column(Integer, ForeignKey('bucket.id', ondelete='CASCADE'))
+    bucket = relationship(
+        'Bucket',
+        backref=backref('project_to_buckets', cascade='all, delete-orphan'),
+        passive_deletes=True
+    )
     privilege = Column(ARRAY(String))
 
 
@@ -442,17 +477,17 @@ class ComputeAccess(Base):
     id = Column(Integer, primary_key=True)
 
     # compute access can be linked to a project/research group/user
-    project_id = Column(Integer, ForeignKey("project.id"))
-    project = relationship("Project", backref="compute_access")
+    project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
+    project = relationship('Project', backref=backref('compute_access', cascade='all, delete-orphan'), passive_deletes=True)
 
-    user_id = Column(Integer, ForeignKey(User.id))
-    user = relationship("User", backref="compute_access")
+    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user = relationship('User', backref=backref('compute_access', cascade='all, delete-orphan'), passive_deletes=True)
 
-    group_id = Column(Integer, ForeignKey("Group.id"))
-    group = relationship("Group", backref="compute_access")
+    group_id = Column(Integer, ForeignKey('Group.id', ondelete='CASCADE'))
+    group = relationship('Group', backref=backref('compute_access', cascade='all, delete-orphan'), passive_deletes=True)
 
-    provider_id = Column(Integer, ForeignKey("cloud_provider.id"))
-    provider = relationship("CloudProvider", backref="compute_access")
+    provider_id = Column(Integer, ForeignKey('cloud_provider.id', ondelete='CASCADE'))
+    provider = relationship('CloudProvider', backref=backref('compute_access', cascade='all, delete-orphan'), passive_deletes=True)
 
     instances = Column(Integer)
     cores = Column(Integer)
@@ -477,17 +512,17 @@ class StorageAccess(Base):
     )
     id = Column(Integer, primary_key=True)
 
-    project_id = Column(Integer, ForeignKey("project.id"))
-    project = relationship("Project", backref="storage_access")
+    project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
+    project = relationship('Project', backref=backref('storage_access', cascade='all, delete-orphan'), passive_deletes=True)
 
-    user_id = Column(Integer, ForeignKey(User.id))
-    user = relationship("User", backref="storage_access")
+    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user = relationship('User', backref=backref('storage_access', cascade='all, delete-orphan'), passive_deletes=True)
 
-    group_id = Column(Integer, ForeignKey("Group.id"))
-    group = relationship("Group", backref="storage_access")
+    group_id = Column(Integer, ForeignKey('Group.id', ondelete='CASCADE'))
+    group = relationship('Group', backref=backref('storage_access', cascade='all, delete-orphan'), passive_deletes=True)
 
-    provider_id = Column(Integer, ForeignKey("cloud_provider.id"))
-    provider = relationship("CloudProvider", backref="storage_access")
+    provider_id = Column(Integer, ForeignKey('cloud_provider.id', ondelete='CASCADE'))
+    provider = relationship('CloudProvider', backref=backref('storage_access', cascade='all, delete-orphan'), passive_deletes=True)
 
     max_objects = Column(BigInteger)
     max_size = Column(BigInteger)
@@ -536,7 +571,6 @@ class Application(Base):
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey(User.id))
     resources_granted = Column(ARRAY(String))  # eg: ['compute', 'storage']
-    certificates_uploaded = relationship("Certificate", backref="user")
     message = Column(String)
 
 
@@ -544,7 +578,12 @@ class Certificate(Base):
     __tablename__ = "certificate"
 
     id = Column(Integer, primary_key=True)
-    application_id = Column(Integer, ForeignKey("application.id"))
+    application_id = Column(Integer, ForeignKey('application.id', ondelete='CASCADE'))
+    application = relationship(
+            "Application",
+            backref=backref("certificates", cascade="all, delete-orphan"),
+            passive_deletes=True
+    )
     name = Column(String(40))
     extension = Column(String)
     data = Column(LargeBinary)
@@ -558,8 +597,12 @@ class S3Credential(Base):
     __tablename__ = "s3credential"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id))
-    user = relationship("User", backref="s3credentials")
+    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user = relationship(
+            'User',
+            backref=backref('s3credentials', cascade='all, delete-orphan'),
+            passive_deletes=True
+    )
 
     access_key = Column(String)
 
@@ -570,7 +613,11 @@ class S3Credential(Base):
 class Tag(Base):
     __tablename__ = "tag"
 
-    user_id = Column(Integer, ForeignKey(User.id), primary_key=True)
+    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'), primary_key=True)
     key = Column(String, primary_key=True)
     value = Column(String)
-    user = relationship("User", backref=backref("tags", cascade="all, delete-orphan"))
+    user = relationship(
+        'User',
+        backref=backref('tags', cascade='all, delete-orphan'),
+        passive_deletes=True
+    )

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -81,9 +81,8 @@ class User(Base):
     google_proxy_group_id = Column(String, ForeignKey("google_proxy_group.id"))
 
     google_proxy_group = relationship(
-        "GoogleProxyGroup",
-        backref=backref(__tablename__, uselist=False, cascade="all, delete-orphan"),
-    )
+        'GoogleProxyGroup', backref=backref(
+            __tablename__, uselist=False, cascade='save-update, merge, refresh-expire, expunge'))
 
     department_id = Column(Integer, ForeignKey("department.id"))
     department = relationship("Department", backref="users")

--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -81,8 +81,13 @@ class User(Base):
     google_proxy_group_id = Column(String, ForeignKey("google_proxy_group.id"))
 
     google_proxy_group = relationship(
-        'GoogleProxyGroup', backref=backref(
-            __tablename__, uselist=False, cascade='save-update, merge, refresh-expire, expunge'))
+        "GoogleProxyGroup",
+        backref=backref(
+            __tablename__,
+            uselist=False,
+            cascade="save-update, merge, refresh-expire, expunge",
+        ),
+    )
 
     department_id = Column(Integer, ForeignKey("department.id"))
     department = relationship("Department", backref="users")
@@ -160,10 +165,12 @@ class HMACKeyPair(Base):
     __tablename__ = "hmac_keypair"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"))
     user = relationship(
-            'User',
-            backref=backref('hmac_keypairs', cascade="all, delete-orphan", passive_deletes=True),
+        "User",
+        backref=backref(
+            "hmac_keypairs", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
     access_key = Column(String)
@@ -220,10 +227,12 @@ class HMACKeyPairArchive(Base):
     __tablename__ = "hmac_keypair_archive"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"))
     user = relationship(
-            'User',
-            backref=backref('archive_keypairs', cascade="all, delete-orphan", passive_deletes=True),
+        "User",
+        backref=backref(
+            "archive_keypairs", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
     access_key = Column(String)
@@ -238,17 +247,29 @@ class UserToGroup(Base):
     """
     Edge table between user and group
     """
-    __tablename__ = 'user_to_group'
-    user_id = Column('user_id', Integer, ForeignKey('User.id', ondelete='CASCADE'), primary_key=True)
+
+    __tablename__ = "user_to_group"
+    user_id = Column(
+        "user_id", Integer, ForeignKey("User.id", ondelete="CASCADE"), primary_key=True
+    )
     user = relationship(
         User,
-        backref=backref('user_to_groups', cascade='all, delete-orphan', passive_deletes=True),
+        backref=backref(
+            "user_to_groups", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
-    group_id = Column('group_id', Integer, ForeignKey('Group.id', ondelete='CASCADE'), primary_key=True)
+    group_id = Column(
+        "group_id",
+        Integer,
+        ForeignKey("Group.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
     group = relationship(
-        'Group',
-        backref=backref('user_to_groups', cascade='all, delete-orphan', passive_deletes=True),
+        "Group",
+        backref=backref(
+            "user_to_groups", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
     roles = Column("roles", ARRAY(String))
@@ -290,35 +311,41 @@ class AccessPrivilege(Base):
     )
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"))
     user = relationship(
         User,
         backref=backref(
-            'accesses_privilege',
-            collection_class=attribute_mapped_collection('pj'),
+            "accesses_privilege",
+            collection_class=attribute_mapped_collection("pj"),
             cascade="all, delete-orphan",
             passive_deletes=True,
         ),
     )
 
-    group_id = Column(Integer, ForeignKey('Group.id', ondelete='CASCADE'))
+    group_id = Column(Integer, ForeignKey("Group.id", ondelete="CASCADE"))
     group = relationship(
-        'Group',
-        backref=backref('accesses_privilege', cascade='all, delete-orphan', passive_deletes=True),
+        "Group",
+        backref=backref(
+            "accesses_privilege", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
-    project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
+    project_id = Column(Integer, ForeignKey("project.id", ondelete="CASCADE"))
     project = relationship(
-        'Project',
-        backref=backref('accesses_privilege', cascade='all, delete-orphan', passive_deletes=True),
+        "Project",
+        backref=backref(
+            "accesses_privilege", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
     pj = association_proxy("project", "auth_id")
 
     privilege = Column(ARRAY(String))
-    provider_id = Column(Integer, ForeignKey('authorization_provider.id', ondelete='CASCADE'))
+    provider_id = Column(
+        Integer, ForeignKey("authorization_provider.id", ondelete="CASCADE")
+    )
     auth_provider = relationship(
-        'AuthorizationProvider',
-        backref=backref('acls', cascade='all, delete-orphan', passive_deletes=True),
+        "AuthorizationProvider",
+        backref=backref("acls", cascade="all, delete-orphan", passive_deletes=True),
     )
 
     def __str__(self):
@@ -338,19 +365,24 @@ class AccessPrivilege(Base):
 
 class UserToBucket(Base):
     """Unused"""
-    __tablename__ = 'user_to_bucket'
+
+    __tablename__ = "user_to_bucket"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"))
     user = relationship(
         User,
-        backref=backref('user_to_buckets', cascade='all, delete-orphan', passive_deletes=True),
+        backref=backref(
+            "user_to_buckets", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
-    bucket_id = Column(Integer, ForeignKey('bucket.id', ondelete='CASCADE'))
+    bucket_id = Column(Integer, ForeignKey("bucket.id", ondelete="CASCADE"))
     bucket = relationship(
-        'Bucket',
-        backref=backref('user_to_buckets', cascade='all, delete-orphan', passive_deletes=True),
+        "Bucket",
+        backref=backref(
+            "user_to_buckets", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
     privilege = Column(ARRAY(String))
 
@@ -392,14 +424,12 @@ class Bucket(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String)
-    provider_id = Column(Integer, ForeignKey('cloud_provider.id', ondelete='CASCADE'))
+    provider_id = Column(Integer, ForeignKey("cloud_provider.id", ondelete="CASCADE"))
     provider = relationship(
-       'CloudProvider',
-       backref=backref('buckets', cascade='all, delete-orphan', passive_deletes=True),
+        "CloudProvider",
+        backref=backref("buckets", cascade="all, delete-orphan", passive_deletes=True),
     )
-    users = association_proxy(
-        'user_to_buckets',
-        'user')
+    users = association_proxy("user_to_buckets", "user")
 
 
 class CloudProvider(Base):
@@ -444,16 +474,20 @@ class ProjectToBucket(Base):
     __tablename__ = "project_to_bucket"
 
     id = Column(Integer, primary_key=True)
-    project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
+    project_id = Column(Integer, ForeignKey("project.id", ondelete="CASCADE"))
     project = relationship(
         Project,
-        backref=backref('project_to_buckets', cascade='all, delete-orphan', passive_deletes=True),
+        backref=backref(
+            "project_to_buckets", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
-    bucket_id = Column(Integer, ForeignKey('bucket.id', ondelete='CASCADE'))
+    bucket_id = Column(Integer, ForeignKey("bucket.id", ondelete="CASCADE"))
     bucket = relationship(
-        'Bucket',
-        backref=backref('project_to_buckets', cascade='all, delete-orphan', passive_deletes=True),
+        "Bucket",
+        backref=backref(
+            "project_to_buckets", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
     privilege = Column(ARRAY(String))
 
@@ -464,17 +498,37 @@ class ComputeAccess(Base):
     id = Column(Integer, primary_key=True)
 
     # compute access can be linked to a project/research group/user
-    project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
-    project = relationship('Project', backref=backref('compute_access', cascade='all, delete-orphan', passive_deletes=True))
+    project_id = Column(Integer, ForeignKey("project.id", ondelete="CASCADE"))
+    project = relationship(
+        "Project",
+        backref=backref(
+            "compute_access", cascade="all, delete-orphan", passive_deletes=True
+        ),
+    )
 
-    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
-    user = relationship('User', backref=backref('compute_access', cascade='all, delete-orphan', passive_deletes=True))
+    user_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"))
+    user = relationship(
+        "User",
+        backref=backref(
+            "compute_access", cascade="all, delete-orphan", passive_deletes=True
+        ),
+    )
 
-    group_id = Column(Integer, ForeignKey('Group.id', ondelete='CASCADE'))
-    group = relationship('Group', backref=backref('compute_access', cascade='all, delete-orphan', passive_deletes=True))
+    group_id = Column(Integer, ForeignKey("Group.id", ondelete="CASCADE"))
+    group = relationship(
+        "Group",
+        backref=backref(
+            "compute_access", cascade="all, delete-orphan", passive_deletes=True
+        ),
+    )
 
-    provider_id = Column(Integer, ForeignKey('cloud_provider.id', ondelete='CASCADE'))
-    provider = relationship('CloudProvider', backref=backref('compute_access', cascade='all, delete-orphan', passive_deletes=True))
+    provider_id = Column(Integer, ForeignKey("cloud_provider.id", ondelete="CASCADE"))
+    provider = relationship(
+        "CloudProvider",
+        backref=backref(
+            "compute_access", cascade="all, delete-orphan", passive_deletes=True
+        ),
+    )
 
     instances = Column(Integer)
     cores = Column(Integer)
@@ -499,17 +553,37 @@ class StorageAccess(Base):
     )
     id = Column(Integer, primary_key=True)
 
-    project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'))
-    project = relationship('Project', backref=backref('storage_access', cascade='all, delete-orphan', passive_deletes=True))
+    project_id = Column(Integer, ForeignKey("project.id", ondelete="CASCADE"))
+    project = relationship(
+        "Project",
+        backref=backref(
+            "storage_access", cascade="all, delete-orphan", passive_deletes=True
+        ),
+    )
 
-    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
-    user = relationship('User', backref=backref('storage_access', cascade='all, delete-orphan', passive_deletes=True))
+    user_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"))
+    user = relationship(
+        "User",
+        backref=backref(
+            "storage_access", cascade="all, delete-orphan", passive_deletes=True
+        ),
+    )
 
-    group_id = Column(Integer, ForeignKey('Group.id', ondelete='CASCADE'))
-    group = relationship('Group', backref=backref('storage_access', cascade='all, delete-orphan', passive_deletes=True))
+    group_id = Column(Integer, ForeignKey("Group.id", ondelete="CASCADE"))
+    group = relationship(
+        "Group",
+        backref=backref(
+            "storage_access", cascade="all, delete-orphan", passive_deletes=True
+        ),
+    )
 
-    provider_id = Column(Integer, ForeignKey('cloud_provider.id', ondelete='CASCADE'))
-    provider = relationship('CloudProvider', backref=backref('storage_access', cascade='all, delete-orphan', passive_deletes=True))
+    provider_id = Column(Integer, ForeignKey("cloud_provider.id", ondelete="CASCADE"))
+    provider = relationship(
+        "CloudProvider",
+        backref=backref(
+            "storage_access", cascade="all, delete-orphan", passive_deletes=True
+        ),
+    )
 
     max_objects = Column(BigInteger)
     max_size = Column(BigInteger)
@@ -565,10 +639,12 @@ class Certificate(Base):
     __tablename__ = "certificate"
 
     id = Column(Integer, primary_key=True)
-    application_id = Column(Integer, ForeignKey('application.id', ondelete='CASCADE'))
+    application_id = Column(Integer, ForeignKey("application.id", ondelete="CASCADE"))
     application = relationship(
-            "Application",
-            backref=backref("certificates", cascade="all, delete-orphan", passive_deletes=True),
+        "Application",
+        backref=backref(
+            "certificates", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
     name = Column(String(40))
     extension = Column(String)
@@ -583,10 +659,12 @@ class S3Credential(Base):
     __tablename__ = "s3credential"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'))
+    user_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"))
     user = relationship(
-            'User',
-            backref=backref('s3credentials', cascade='all, delete-orphan', passive_deletes=True),
+        "User",
+        backref=backref(
+            "s3credentials", cascade="all, delete-orphan", passive_deletes=True
+        ),
     )
 
     access_key = Column(String)
@@ -598,10 +676,10 @@ class S3Credential(Base):
 class Tag(Base):
     __tablename__ = "tag"
 
-    user_id = Column(Integer, ForeignKey(User.id, ondelete='CASCADE'), primary_key=True)
+    user_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"), primary_key=True)
     key = Column(String, primary_key=True)
     value = Column(String)
     user = relationship(
-        'User',
-        backref=backref('tags', cascade='all, delete-orphan', passive_deletes=True),
+        "User",
+        backref=backref("tags", cascade="all, delete-orphan", passive_deletes=True),
     )


### PR DESCRIPTION
### New Features

### Breaking Changes

### Bug Fixes

### Improvements
Set `ON DELETE CASCADE` property where it makes sense to do so. Then (for example) when a 'User' is deleted, the delete will automatically cascade to everything belonging to the user. Cascade property is set at DB level as opposed to ORM level. The other half of this logical change will happen in the Fence repo. 

### Dependency updates

### Deployment changes

