### PR TITLE
Set ondelete SET NULL on User.google_proxy_group_id

### DIFF
--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -78,7 +78,7 @@ class User(Base):
     idp_id = Column(Integer, ForeignKey("identity_provider.id"))
     identity_provider = relationship("IdentityProvider", backref="users")
 
-    google_proxy_group_id = Column(String, ForeignKey("google_proxy_group.id"))
+    google_proxy_group_id = Column(String, ForeignKey("google_proxy_group.id", ondelete="SET NULL"))
 
     google_proxy_group = relationship(
         "GoogleProxyGroup",


### PR DESCRIPTION
The migration was already setting ondelete="SET NULL" for User.google_proxy_group_id, but this should also be in the table definition.

### Bug Fixes
set ondelete SET NULL on User.google_proxy_group_id

