### PR TITLE
PXP-4641 Feat/username limit

### DIFF
--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -54,7 +54,7 @@ class User(Base):
     __tablename__ = "User"
 
     id = Column(Integer, primary_key=True)
-    username = Column(String(40), unique=True)
+    username = Column(String(255), unique=True)
 
     # id from identifier, which is not guarenteed to be unique
     # across all identifiers.


### PR DESCRIPTION
This PR fulfills https://ctds-planx.atlassian.net/browse/PXP-4641

Lift up the length limit for `username` filed, which is causing issues now for users with long email addresses

### Improvements
- Lift length limit for `username` filed from 40 to 255 chars


