### PR TITLE
PXP-4319 feat/add cert audit logs table

### DIFF
--- a/userdatamodel/user.py
+++ b/userdatamodel/user.py
@@ -132,6 +132,18 @@ class UserAuditLog(Base):
     new_values = Column(JSONB, server_default=text("'{}'"))
 
 
+class CertAuditLog(Base):
+    __tablename__ = "cert_audit_logs"
+
+    id = Column(BigInteger, primary_key=True)
+    timestamp = Column(DateTime, server_default=text("now()"), nullable=False)
+    operation = Column(String, nullable=False)
+    user_id = Column(Integer, nullable=False)
+    username = Column(String(255), nullable=False)
+    old_values = Column(JSONB, server_default=text("'{}'"))
+    new_values = Column(JSONB, server_default=text("'{}'"))
+
+
 class GoogleProxyGroup(Base):
     __tablename__ = "google_proxy_group"
 


### PR DESCRIPTION
This PR is a part of https://ctds-planx.atlassian.net/browse/PXP-4319

Get a `cert_audit_logs` table in Fence DB for trigger function on the `certificate` table, to record when a user has submitted a ToU/PP cert

Fence PR https://github.com/uc-cdis/fence/pull/738 requires this

### New Features
- New `cert_audit_logs` table in Fence DB for trigger function on the `certificate` table



