### PR TITLE
Update Pipfile to use Python 3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 userdatamodel = {editable = true,path = "."}
+sqlalchemy = ">=1.3.0"
 
 [requires]
-python_version = "2.7"
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3caf283c6a144dfeb24d226720c5a51a1d3458799ceedba4f885acc7eb2d7258"
+            "sha256": "74d0af0e07782b281eb32aac82314f20367daeacd70ff9336596ca4ec2b6dad8"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "2.7"
+            "python_version": "3.6"
         },
         "sources": [
             {
@@ -18,15 +18,16 @@
     "default": {
         "cdislogging": {
             "hashes": [
-                "sha256:4868a18c294e9796479824496ebaa7c4b9ae6175e5bade2e5051c838f84f42e9"
+                "sha256:a1cc2e48d5fc26d4b354b80c6497f1f1136f3e3e4f1d1855de8980ccf497fa0a"
             ],
-            "version": "==0.1.1"
+            "version": "==1.0.0"
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:445cba2d5e36b9334aa06c06e00fbedb71f1b1dd03d1d2763b6cf77b9cd6163b"
+                "sha256:afa5541e9dea8ad0014251bc9d56171ca3d8b130c9627c6cb3681cff30be3f8a"
             ],
-            "version": "==0.9.10"
+            "index": "pypi",
+            "version": "==1.3.11"
         },
         "userdatamodel": {
             "editable": true,


### PR DESCRIPTION
* requires sqlalchemy > 1.3.0 per security vulnerabilities
* updates pipfile to use python 3
